### PR TITLE
GH Workflow: setup-ruby@v1 is deprecated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,17 @@
-on: push
+name: build gh-pages
+on: [push, pull_request]
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: script/cibuild
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ruby: ['2.7', '3.1']
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-      - name: build
-        run: script/bootstrap
-      - name: test
-        run: script/cibuild
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
    Run actions/setup-ruby@v1
      with:
        ruby-version: 2.7
    ------------------------
    NOTE: This action is deprecated and is no longer maintained.
    Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
    ------------------------

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>